### PR TITLE
Trim empty properties from statement before preparing it to be sent. 

### DIFF
--- a/src/TinCan.js
+++ b/src/TinCan.js
@@ -365,7 +365,7 @@ var TinCan;
             ;
 
             if (rsCount > 0) {
-                statement = this.prepareStatement(stmt);
+                statement = this.prepareStatement(this.Utils.deleteEmptyProperties(stmt));
 
                 /*
                    when there are multiple LRSes configured and

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -167,5 +167,19 @@ TinCan client library
             var urlParts = absoluteUrl.split("/");
             return urlParts[0] + "//" + urlParts[2];
         }
+        deleteEmptyProperties: function (objectToTest)
+		{ 
+		    if (typeof objectToTest=="object"){
+		        for (i in objectToTest) {
+		            if (objectToTest[i] == null || objectToTest[i] == "" || (JSON.stringify(objectToTest[i])=="{}")) {
+		                delete objectToTest[i];
+		            }
+		            else {
+		                this.Utils.deleteEmptyProperties(objectToTest[i]);
+		            }
+		        }
+		    }
+			return objectToTest;
+		}
     };
 }());


### PR DESCRIPTION
Note: this is not ready to be merged as I have not yet tested it. 

The problem this addresses is that some LRSes do not accept null values for properties, so this function iterates through the object and deletes any empty properties. 
