### PR TITLE
Added objectType property

### DIFF
--- a/src/Agent.js
+++ b/src/Agent.js
@@ -33,7 +33,7 @@ TinCan client library
         /**
         @property objectType
         @type String
-        @default Activity
+        @default Agent
         */
         this.objectType = "Agent";
         


### PR DESCRIPTION
This fixes a bug where when getting statements if the object of the statement is an agent, the agent has no objectType property. 

The code is copy and pasted from activity.js but Activity is replaced with Agent.
