### PR TITLE
fix error when interaction components not used in chrome

### DIFF
--- a/src/ActivityDefinition.js
+++ b/src/ActivityDefinition.js
@@ -274,7 +274,7 @@ TinCan client library
 
             for (i = 0; i < interactionComponentProps.length; i += 1) {
                 prop = interactionComponentProps[i];
-                if (this[prop] !== null) {
+ 				if (this.hasOwnProperty(prop) && this[prop] !== null) {
                     result[prop] = [];
                     for (j = 0; j < this[prop].length; j += 1) {
                         result[prop].push(


### PR DESCRIPTION
Just a minor fix. 

I'm not sure what's going on with the line lengths - they look the same on my computer but seem to have changed in the diff. Any ideas?
