### PR TITLE
Allow for score : null in cfg

### DIFF
--- a/src/Result.js
+++ b/src/Result.js
@@ -98,7 +98,7 @@ TinCan client library
 
             cfg = cfg || {};
 
-            if (cfg.hasOwnProperty("score")) {
+            if (cfg.hasOwnProperty("score") && cfg.score !== null) {
                 if (cfg.score instanceof TinCan.Score) {
                     this.score = cfg.score;
                 }


### PR DESCRIPTION
This allows you to do something like:

var myResult = new TinCan.Result({score : myScore});

where myScore may or may not be null.
