### PR TITLE
Node fix to check for params

### DIFF
--- a/src/Environment/Node.js
+++ b/src/Environment/Node.js
@@ -89,7 +89,7 @@ TinCan client library
             async = typeof cfg.callback !== "undefined",
             prop
         ;
-        if (Object.keys(cfg.params).length > 0) {
+        if (typeof cfg.params !== "undefined" && Object.keys(cfg.params).length > 0) {
             url += "?" + querystring.stringify(cfg.params);
         }
 


### PR DESCRIPTION
Guard condition for cfg.params when a request is made in the Node environment.
- [x] Node
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] IE11
- [ ] IE10
- [ ] IE9
- [ ] IE8
- [ ] IE7
- [ ] IE6
  @brianjmiller over to you for IE wrangling :+1: 
