### PR TITLE
added doc clarification

### DIFF
--- a/src/TinCan.js
+++ b/src/TinCan.js
@@ -722,11 +722,15 @@ var TinCan;
         @param {Object} [cfg] Configuration for request
             @param {Boolean} [cfg.sendActor] Include default actor in query params
             @param {Boolean} [cfg.sendActivity] Include default activity in query params
-            @param {Object} [cfg.params] Parameters used to filter
+            @param {Object} [cfg.params] Parameters used to filter. 
+                            These are the same those accepted by the
+                            <a href="TinCan.LRS.html#method_queryStatements">LRS.queryStatements</a>
+                            method.
 
             @param {Function} [cfg.callback] Function to run at completion
 
         TODO: support multiple LRSs and flag to use single
+        
         */
         getStatements: function (cfg) {
             this.log("getStatements");


### PR DESCRIPTION
Hi,

I added a reference in the docs from the TinCan.getStatements function to the LRS.queryStatements, in order to make it a bit clearer what parameters it is possible to query on. The TinCan.getStatements is often close to the "first impression" that people have when using this library, so therefore I felt that this was beneficial. 
