### PR TITLE
Allow forced no registration and POST method for setState

### DIFF
--- a/src/LRS.js
+++ b/src/LRS.js
@@ -994,7 +994,7 @@ TinCan client library
             if (typeof val === "object" && TinCan.Utils.isApplicationJSON(cfg.contentType)) {
                 val = JSON.stringify(val);
             }
-			
+
             if (typeof cfg.method === "undefined" || cfg.method !== "POST") {
                 cfg.method = "PUT";
             }

--- a/src/LRS.js
+++ b/src/LRS.js
@@ -1212,6 +1212,7 @@ TinCan client library
             @param {Object} cfg.activity TinCan.Activity
             @param {String} [cfg.lastSHA1] SHA1 of the previously seen existing profile
             @param {String} [cfg.contentType] Content-Type to specify in headers (defaults to 'application/octet-stream')
+            @param {String} [cfg.method] Method to use. Default: PUT
             @param {Function} [cfg.callback] Callback to execute on completion
         */
         saveActivityProfile: function (key, val, cfg) {
@@ -1222,13 +1223,17 @@ TinCan client library
                 cfg.contentType = "application/octet-stream";
             }
 
+            if (typeof cfg.method === "undefined" || cfg.method !== "POST") {
+                cfg.method = "PUT";
+            }
+
             if (typeof val === "object" && TinCan.Utils.isApplicationJSON(cfg.contentType)) {
                 val = JSON.stringify(val);
             }
 
             requestCfg = {
                 url: "activities/profile",
-                method: "PUT",
+                method: cfg.method,
                 params: {
                     profileId: key,
                     activityId: cfg.activity.id
@@ -1414,6 +1419,7 @@ TinCan client library
             @param {Object} cfg.agent TinCan.Agent
             @param {String} [cfg.lastSHA1] SHA1 of the previously seen existing profile
             @param {String} [cfg.contentType] Content-Type to specify in headers (defaults to 'application/octet-stream')
+            @param {String} [cfg.method] Method to use. Default: PUT
             @param {Function} [cfg.callback] Callback to execute on completion
         */
         saveAgentProfile: function (key, val, cfg) {
@@ -1424,12 +1430,16 @@ TinCan client library
                 cfg.contentType = "application/octet-stream";
             }
 
+            if (typeof cfg.method === "undefined" || cfg.method !== "POST") {
+                cfg.method = "PUT";
+            }
+
             if (typeof val === "object" && TinCan.Utils.isApplicationJSON(cfg.contentType)) {
                 val = JSON.stringify(val);
             }
 
             requestCfg = {
-                method: "PUT",
+                method: cfg.method,
                 params: {
                     profileId: key
                 },

--- a/src/LRS.js
+++ b/src/LRS.js
@@ -863,7 +863,7 @@ TinCan client library
             else {
                 requestParams.agent = JSON.stringify(cfg.agent.asVersion(this.version));
             }
-            if (typeof cfg.registration !== "undefined") {
+            if ((typeof cfg.registration !== "undefined") && (cfg.registration !== null)) {
                 if (this.version === "0.9") {
                     requestParams.registrationId = cfg.registration;
                 }
@@ -1009,7 +1009,7 @@ TinCan client library
             else {
                 requestParams.agent = JSON.stringify(cfg.agent.asVersion(this.version));
             }
-            if (typeof cfg.registration !== "undefined") {
+            if ((typeof cfg.registration !== "undefined") && (cfg.registration !== null)) {
                 if (this.version === "0.9") {
                     requestParams.registrationId = cfg.registration;
                 }
@@ -1066,7 +1066,7 @@ TinCan client library
             if (key !== null) {
                 requestParams.stateId = key;
             }
-            if (typeof cfg.registration !== "undefined") {
+            if ((typeof cfg.registration !== "undefined") && (cfg.registration !== null)) {
                 if (this.version === "0.9") {
                     requestParams.registrationId = cfg.registration;
                 }

--- a/src/LRS.js
+++ b/src/LRS.js
@@ -979,6 +979,7 @@ TinCan client library
             @param {String} [cfg.registration] Registration
             @param {String} [cfg.lastSHA1] SHA1 of the previously seen existing state
             @param {String} [cfg.contentType] Content-Type to specify in headers (defaults to 'application/octet-stream')
+            @param {String} [cfg.method] Method to use. Default: PUT
             @param {Function} [cfg.callback] Callback to execute on completion
         */
         saveState: function (key, val, cfg) {
@@ -992,6 +993,10 @@ TinCan client library
 
             if (typeof val === "object" && TinCan.Utils.isApplicationJSON(cfg.contentType)) {
                 val = JSON.stringify(val);
+            }
+			
+            if (typeof cfg.method === "undefined" || cfg.method !== "POST") {
+                cfg.method = "PUT";
             }
 
             requestParams = {
@@ -1015,7 +1020,7 @@ TinCan client library
 
             requestCfg = {
                 url: "activities/state",
-                method: "PUT",
+                method: cfg.method,
                 params: requestParams,
                 data: val,
                 headers: {

--- a/src/TinCan.js
+++ b/src/TinCan.js
@@ -848,6 +848,7 @@ var TinCan;
                 defaults to 'registration' property if empty
             @param {String} [cfg.lastSHA1] SHA1 of the previously seen existing state
             @param {String} [cfg.contentType] Content-Type to specify in headers
+            @param {Boolean} [cfg.overwriteJSON] If the Content-Type is JSON, should a PUT be used? 
             @param {Function} [cfg.callback] Function to run with state
         */
         setState: function (key, val, cfg) {
@@ -874,7 +875,9 @@ var TinCan;
                     activity: (typeof cfg.activity !== "undefined" ? cfg.activity : this.activity)
                 };
                 if (typeof cfg.registration !== "undefined") {
-                    queryCfg.registration = cfg.registration;
+                    if (cfg.registration !== null) {
+                        queryCfg.registration = cfg.registration;
+                    }
                 }
                 else if (this.registration !== null) {
                     queryCfg.registration = this.registration;
@@ -884,6 +887,9 @@ var TinCan;
                 }
                 if (typeof cfg.contentType !== "undefined") {
                     queryCfg.contentType = cfg.contentType;
+                    if ((typeof cfg.overwriteJSON !== "undefined") && (!cfg.overwriteJSON) && (TinCan.Utils.isApplicationJSON(cfg.contentType))) {
+                        queryCfg.method = "POST";
+                    }
                 }
                 if (typeof cfg.callback !== "undefined") {
                     queryCfg.callback = cfg.callback;

--- a/src/TinCan.js
+++ b/src/TinCan.js
@@ -819,7 +819,7 @@ var TinCan;
                     agent: (typeof cfg.agent !== "undefined" ? cfg.agent : this.actor),
                     activity: (typeof cfg.activity !== "undefined" ? cfg.activity : this.activity)
                 };
-                if ((typeof cfg.registration !== "undefined") && (cfg.registration !== null)) {
+                if (typeof cfg.registration !== "undefined") {
                     queryCfg.registration = cfg.registration;
                 }
                 else if (this.registration !== null) {
@@ -874,7 +874,7 @@ var TinCan;
                     agent: (typeof cfg.agent !== "undefined" ? cfg.agent : this.actor),
                     activity: (typeof cfg.activity !== "undefined" ? cfg.activity : this.activity)
                 };
-                if ((typeof cfg.registration !== "undefined") && (cfg.registration !== null)) {
+                if (typeof cfg.registration !== "undefined") {
                     queryCfg.registration = cfg.registration;
                 }
                 else if (this.registration !== null) {
@@ -934,7 +934,7 @@ var TinCan;
                     agent: (typeof cfg.agent !== "undefined" ? cfg.agent : this.actor),
                     activity: (typeof cfg.activity !== "undefined" ? cfg.activity : this.activity)
                 };
-                if ((typeof cfg.registration !== "undefined") && (cfg.registration !== null)) {
+                if (typeof cfg.registration !== "undefined") {
                     queryCfg.registration = cfg.registration;
                 }
                 else if (this.registration !== null) {

--- a/src/TinCan.js
+++ b/src/TinCan.js
@@ -887,7 +887,7 @@ var TinCan;
                 }
                 if (typeof cfg.contentType !== "undefined") {
                     queryCfg.contentType = cfg.contentType;
-                    if ((typeof cfg.overwriteJSON !== "undefined") && (!cfg.overwriteJSON) && (TinCan.Utils.isApplicationJSON(cfg.contentType))) {
+                    if ((typeof cfg.overwriteJSON !== "undefined") && (! cfg.overwriteJSON) && (TinCan.Utils.isApplicationJSON(cfg.contentType))) {
                         queryCfg.method = "POST";
                     }
                 }

--- a/src/TinCan.js
+++ b/src/TinCan.js
@@ -874,10 +874,8 @@ var TinCan;
                     agent: (typeof cfg.agent !== "undefined" ? cfg.agent : this.actor),
                     activity: (typeof cfg.activity !== "undefined" ? cfg.activity : this.activity)
                 };
-                if (typeof cfg.registration !== "undefined") {
-                    if (cfg.registration !== null) {
-                        queryCfg.registration = cfg.registration;
-                    }
+                if ((typeof cfg.registration !== "undefined") && (cfg.registration !== null)) {
+                    queryCfg.registration = cfg.registration;
                 }
                 else if (this.registration !== null) {
                     queryCfg.registration = this.registration;
@@ -936,7 +934,7 @@ var TinCan;
                     agent: (typeof cfg.agent !== "undefined" ? cfg.agent : this.actor),
                     activity: (typeof cfg.activity !== "undefined" ? cfg.activity : this.activity)
                 };
-                if (typeof cfg.registration !== "undefined") {
+                if ((typeof cfg.registration !== "undefined") && (cfg.registration !== null)) {
                     queryCfg.registration = cfg.registration;
                 }
                 else if (this.registration !== null) {
@@ -1001,6 +999,7 @@ var TinCan;
                 defaults to 'activity' property if empty
             @param {String} [cfg.lastSHA1] SHA1 of the previously seen existing profile
             @param {String} [cfg.contentType] Content-Type to specify in headers
+            @param {Boolean} [cfg.overwriteJSON] If the Content-Type is JSON, should a PUT be used?
             @param {Function} [cfg.callback] Function to run with activity profile
         */
         setActivityProfile: function (key, val, cfg) {
@@ -1033,6 +1032,9 @@ var TinCan;
                 }
                 if (typeof cfg.contentType !== "undefined") {
                     queryCfg.contentType = cfg.contentType;
+                    if ((typeof cfg.overwriteJSON !== "undefined") && (! cfg.overwriteJSON) && (TinCan.Utils.isApplicationJSON(cfg.contentType))) {
+                        queryCfg.method = "POST";
+                    }
                 }
 
                 return lrs.saveActivityProfile(key, val, queryCfg);
@@ -1130,6 +1132,7 @@ var TinCan;
                 defaults to 'actor' property if empty
             @param {String} [cfg.lastSHA1] SHA1 of the previously seen existing profile
             @param {String} [cfg.contentType] Content-Type to specify in headers
+            @param {Boolean} [cfg.overwriteJSON] If the Content-Type is JSON, should a PUT be used?
             @param {Function} [cfg.callback] Function to run with agent profile
         */
         setAgentProfile: function (key, val, cfg) {
@@ -1162,6 +1165,9 @@ var TinCan;
                 }
                 if (typeof cfg.contentType !== "undefined") {
                     queryCfg.contentType = cfg.contentType;
+                    if ((typeof cfg.overwriteJSON !== "undefined") && (! cfg.overwriteJSON) && (TinCan.Utils.isApplicationJSON(cfg.contentType))) {
+                        queryCfg.method = "POST";
+                    }
                 }
 
                 return lrs.saveAgentProfile(key, val, queryCfg);

--- a/src/TinCan.js
+++ b/src/TinCan.js
@@ -819,7 +819,7 @@ var TinCan;
                     agent: (typeof cfg.agent !== "undefined" ? cfg.agent : this.actor),
                     activity: (typeof cfg.activity !== "undefined" ? cfg.activity : this.activity)
                 };
-                if (typeof cfg.registration !== "undefined") {
+                if ((typeof cfg.registration !== "undefined") && (cfg.registration !== null)) {
                     queryCfg.registration = cfg.registration;
                 }
                 else if (this.registration !== null) {

--- a/test/js/unit/TinCan-sync.js
+++ b/test/js/unit/TinCan-sync.js
@@ -418,6 +418,122 @@
         );
     };
 
+    doStateUpdateContentTest = function (v) {
+        test(
+            "tincan state (update, JSON content type): " + v,
+            function () {
+                var setResult,
+                    key = "setState (update, json content)",
+                    valFirst = {
+                        testObj: {
+                            key1: "val1"
+                        },
+                        testBool: true,
+                        testNum: 1
+                    },
+                    valUpdate = {
+                        testNewObj: {
+                            key1: "val1"
+                        },
+                        testBool: false,
+                        testNum: 0
+                    },
+                    valResult = {
+                        testObj: {
+                            key1: "val1"
+                        },
+                        testNewObj: {
+                            key1: "val1"
+                        },
+                        testBool: false,
+                        testNum: 0
+                    },
+                    mbox ="mailto:tincanjs-test-tincan+" + Date.now() + "@tincanapi.com",
+                    options = {
+                        contentType: "application/json",
+                        agent: new TinCan.Agent(
+                            {
+                                mbox: mbox
+                            }
+                        ),
+                        activity: new TinCan.Activity(
+                            {
+                                id: "http://tincanapi.com/TinCanJS/Test/TinCan_setState/syncContentType/" + v
+                            }
+                        ),
+                        overwriteJSON: false
+                    };
+
+                session[v].setState(key, valFirst, options);
+                setResult = session[v].setState(key, valUpdate, options);
+
+                ok(setResult.hasOwnProperty("err"), "setResult has property: err (" + v + ")");
+                ok(setResult.hasOwnProperty("xhr"), "setResult has property: xhr (" + v + ")");
+
+                getResult = session[v].getState(key, options);
+                ok(getResult.hasOwnProperty("state"), "getResult has property: state (" + v + ")");
+                ok(getResult.state instanceof TinCan.State, "getResult state property is TinCan.State (" + v + ")");
+                deepEqual(getResult.state.contents, valResult, "getResult state property contents (" + v + ")");
+                deepEqual(TinCan.Utils.getContentTypeFromHeader(getResult.state.contentType), "application/json", "getResult state property contentType (" + v + ")");
+
+                deleteResult = session[v].deleteState(key, options);
+            }
+        );
+    };
+
+        doStateOverwriteContentTest = function (v) {
+        test(
+            "tincan state (overwrite, JSON content type): " + v,
+            function () {
+                var setResult,
+                    key = "setState (overwrite, json content)",
+                    valFirst = {
+                        testObj: {
+                            key1: "val1"
+                        },
+                        testBool: true,
+                        testNum: 1
+                    },
+                    valOverwrite = {
+                        testNewObj: {
+                            key1: "val1"
+                        },
+                        testBool: false,
+                        testNum: 0
+                    }
+                    mbox ="mailto:tincanjs-test-tincan+" + Date.now() + "@tincanapi.com",
+                    options = {
+                        contentType: "application/json",
+                        agent: new TinCan.Agent(
+                            {
+                                mbox: mbox
+                            }
+                        ),
+                        activity: new TinCan.Activity(
+                            {
+                                id: "http://tincanapi.com/TinCanJS/Test/TinCan_setState/syncContentType/" + v
+                            }
+                        ),
+                        overwriteJSON: true
+                    };
+
+                session[v].setState(key, valFirst, options);
+                setResult = session[v].setState(key, valOverwrite, options);
+
+                ok(setResult.hasOwnProperty("err"), "setResult has property: err (" + v + ")");
+                ok(setResult.hasOwnProperty("xhr"), "setResult has property: xhr (" + v + ")");
+
+                getResult = session[v].getState(key, options);
+                ok(getResult.hasOwnProperty("state"), "getResult has property: state (" + v + ")");
+                ok(getResult.state instanceof TinCan.State, "getResult state property is TinCan.State (" + v + ")");
+                deepEqual(getResult.state.contents, valOverwrite, "getResult state property contents (" + v + ")");
+                deepEqual(TinCan.Utils.getContentTypeFromHeader(getResult.state.contentType), "application/json", "getResult state property contentType (" + v + ")");
+
+                deleteResult = session[v].deleteState(key, options);
+            }
+        );
+    };
+
     doActivityProfileSyncTest = function (v) {
         test(
             "tincan activityProfile (sync): " + v,
@@ -511,6 +627,110 @@
                 options.lastSHA1 = getResult.profile.etag;
                 setResult = session[v].setActivityProfile(key, val + 2, options);
                 delete options.lastSHA1;
+
+                deleteResult = session[v].deleteActivityProfile(key, options);
+            }
+        );
+    };
+
+    doActivityProfileUpdateContentTest = function (v) {
+        test(
+            "tincan activityProfile (update, JSON content type): " + v,
+            function () {
+                var setResult,
+                    key = "setActivityProfile (update, json content)",
+                    valFirst = {
+                        testObj: {
+                            key1: "val1"
+                        },
+                        testBool: true,
+                        testNum: 1
+                    },
+                    valUpdate = {
+                        testNewObj: {
+                            key1: "val1"
+                        },
+                        testBool: false,
+                        testNum: 0
+                    },
+                    valResult = {
+                        testObj: {
+                            key1: "val1"
+                        },
+                        testNewObj: {
+                            key1: "val1"
+                        },
+                        testBool: false,
+                        testNum: 0
+                    },
+                    options = {
+                        contentType: "application/json",
+                        activity: new TinCan.Activity(
+                            {
+                                id: "http://tincanapi.com/TinCanJS/Test/TinCan_setState/syncContentType/" + v
+                            }
+                        ),
+                        overwriteJSON: false
+                    };
+
+                session[v].setActivityProfile(key, valFirst, options);
+                setResult = session[v].setActivityProfile(key, valUpdate, options);
+
+                ok(setResult.hasOwnProperty("err"), "setResult has property: err (" + v + ")");
+                ok(setResult.hasOwnProperty("xhr"), "setResult has property: xhr (" + v + ")");
+
+                getResult = session[v].getActivityProfile(key, options);
+                ok(getResult.hasOwnProperty("profile"), "getResult has property: profile (" + v + ")");
+                ok(getResult.profile instanceof TinCan.ActivityProfile, "getResult profile property is TinCan.ActivityProfile (" + v + ")");
+                deepEqual(getResult.profile.contents, valResult, "getResult profile property contents (" + v + ")");
+                deepEqual(TinCan.Utils.getContentTypeFromHeader(getResult.profile.contentType), "application/json", "getResult profile property contentType (" + v + ")");
+
+                deleteResult = session[v].deleteActivityProfile(key, options);
+            }
+        );
+    };
+
+    doActivityProfileOverwriteContentTest = function (v) {
+        test(
+            "tincan activityProfile (overwrite, JSON content type): " + v,
+            function () {
+                var setResult,
+                    key = "setActivityProfile (overwrite, json content)",
+                    valFirst = {
+                        testObj: {
+                            key1: "val1"
+                        },
+                        testBool: true,
+                        testNum: 1
+                    },
+                    valOverwrite = {
+                        testNewObj: {
+                            key1: "val1"
+                        },
+                        testBool: false,
+                        testNum: 0
+                    }
+                    options = {
+                        contentType: "application/json",
+                        activity: new TinCan.Activity(
+                            {
+                                id: "http://tincanapi.com/TinCanJS/Test/TinCan_setState/syncContentType/" + v
+                            }
+                        ),
+                        overwriteJSON: true
+                    };
+
+                session[v].setActivityProfile(key, valFirst, options);
+                setResult = session[v].setActivityProfile(key, valOverwrite, options);
+
+                ok(setResult.hasOwnProperty("err"), "setResult has property: err (" + v + ")");
+                ok(setResult.hasOwnProperty("xhr"), "setResult has property: xhr (" + v + ")");
+
+                getResult = session[v].getActivityProfile(key, options);
+                ok(getResult.hasOwnProperty("profile"), "getResult has property: profile (" + v + ")");
+                ok(getResult.profile instanceof TinCan.ActivityProfile, "getResult profile property is TinCan.ActivityProfile (" + v + ")");
+                deepEqual(getResult.profile.contents, valOverwrite, "getResult profile property contents (" + v + ")");
+                deepEqual(TinCan.Utils.getContentTypeFromHeader(getResult.profile.contentType), "application/json", "getResult profile property contentType (" + v + ")");
 
                 deleteResult = session[v].deleteActivityProfile(key, options);
             }
@@ -618,6 +838,112 @@
         );
     };
 
+    doAgentProfileUpdateContentTest = function (v) {
+        test(
+            "tincan agentProfile (update, JSON content type): " + v,
+            function () {
+                var setResult,
+                    key = "setAgentProfile (update, json content)",
+                    valFirst = {
+                        testObj: {
+                            key1: "val1"
+                        },
+                        testBool: true,
+                        testNum: 1
+                    },
+                    valUpdate = {
+                        testNewObj: {
+                            key1: "val1"
+                        },
+                        testBool: false,
+                        testNum: 0
+                    },
+                    valResult = {
+                        testObj: {
+                            key1: "val1"
+                        },
+                        testNewObj: {
+                            key1: "val1"
+                        },
+                        testBool: false,
+                        testNum: 0
+                    },
+                    mbox ="mailto:tincanjs-test-tincan+" + Date.now() + "@tincanapi.com",
+                    options = {
+                        contentType: "application/json",
+                        agent: new TinCan.Agent(
+                            {
+                                mbox: mbox
+                            }
+                        ),
+                        overwriteJSON: false
+                    };
+
+                session[v].setAgentProfile(key, valFirst, options);
+                setResult = session[v].setAgentProfile(key, valUpdate, options);
+
+                ok(setResult.hasOwnProperty("err"), "setResult has property: err (" + v + ")");
+                ok(setResult.hasOwnProperty("xhr"), "setResult has property: xhr (" + v + ")");
+
+                getResult = session[v].getAgentProfile(key, options);
+                ok(getResult.hasOwnProperty("profile"), "getResult has property: profile (" + v + ")");
+                ok(getResult.profile instanceof TinCan.AgentProfile, "getResult profile property is TinCan.AgentProfile (" + v + ")");
+                deepEqual(getResult.profile.contents, valResult, "getResult profile property contents (" + v + ")");
+                deepEqual(TinCan.Utils.getContentTypeFromHeader(getResult.profile.contentType), "application/json", "getResult profile property contentType (" + v + ")");
+
+                deleteResult = session[v].deleteAgentProfile(key, options);
+            }
+        );
+    };
+
+    doAgentProfileOverwriteContentTest = function (v) {
+        test(
+            "tincan agentProfile (overwrite, JSON content type): " + v,
+            function () {
+                var setResult,
+                    key = "setAgentProfile (overwrite, json content)",
+                    valFirst = {
+                        testObj: {
+                            key1: "val1"
+                        },
+                        testBool: true,
+                        testNum: 1
+                    },
+                    valOverwrite = {
+                        testNewObj: {
+                            key1: "val1"
+                        },
+                        testBool: false,
+                        testNum: 0
+                    }
+                    mbox ="mailto:tincanjs-test-tincan+" + Date.now() + "@tincanapi.com",
+                    options = {
+                        contentType: "application/json",
+                        agent: new TinCan.Agent(
+                            {
+                                mbox: mbox
+                            }
+                        ),
+                        overwriteJSON: true
+                    };
+
+                session[v].setAgentProfile(key, valFirst, options);
+                setResult = session[v].setAgentProfile(key, valOverwrite, options);
+
+                ok(setResult.hasOwnProperty("err"), "setResult has property: err (" + v + ")");
+                ok(setResult.hasOwnProperty("xhr"), "setResult has property: xhr (" + v + ")");
+
+                getResult = session[v].getAgentProfile(key, options);
+                ok(getResult.hasOwnProperty("profile"), "getResult has property: profile (" + v + ")");
+                ok(getResult.profile instanceof TinCan.AgentProfile, "getResult profile property is TinCan.AgentProfile (" + v + ")");
+                deepEqual(getResult.profile.contents, valOverwrite, "getResult profile property contents (" + v + ")");
+                deepEqual(TinCan.Utils.getContentTypeFromHeader(getResult.profile.contentType), "application/json", "getResult profile property contentType (" + v + ")");
+
+                deleteResult = session[v].deleteAAgentProfile(key, options);
+            }
+        );
+    };
+
     for (i = 0; i < versions.length; i += 1) {
         version = versions[i];
         if (TinCanTestCfg.recordStores[version]) {
@@ -630,6 +956,14 @@
             doActivityProfileSyncContentTypeJSONTest(version);
             doAgentProfileSyncTest(version);
             doAgentProfileSyncContentTypeJSONTest(version);
+            if ((version ==! "0.95") && (version ==! "0.9")) {
+                doStateUpdateContentTest(version);
+                doStateOverwriteContentTest(version);
+                doActivityProfileUpdateContentTest(version);
+                doActivityProfileOverwriteContentTest(version);
+                doAgentProfileUpdateContentTest(version);
+                doAgentProfileOverwriteContentTest(version);
+            }
         }
     }
 }());

--- a/test/js/unit/TinCan-sync.js
+++ b/test/js/unit/TinCan-sync.js
@@ -481,7 +481,7 @@
         );
     };
 
-        doStateOverwriteContentTest = function (v) {
+    doStateOverwriteContentTest = function (v) {
         test(
             "tincan state (overwrite, JSON content type): " + v,
             function () {
@@ -674,7 +674,10 @@
                     };
 
                 session[v].setActivityProfile(key, valFirst, options);
+                getResult = session[v].getActivityProfile(key, options);
+                options.lastSHA1 = getResult.profile.etag;
                 setResult = session[v].setActivityProfile(key, valUpdate, options);
+                delete options.lastSHA1;
 
                 ok(setResult.hasOwnProperty("err"), "setResult has property: err (" + v + ")");
                 ok(setResult.hasOwnProperty("xhr"), "setResult has property: xhr (" + v + ")");
@@ -721,7 +724,10 @@
                     };
 
                 session[v].setActivityProfile(key, valFirst, options);
+                getResult = session[v].getActivityProfile(key, options);
+                options.lastSHA1 = getResult.profile.etag;
                 setResult = session[v].setActivityProfile(key, valOverwrite, options);
+                delete options.lastSHA1;
 
                 ok(setResult.hasOwnProperty("err"), "setResult has property: err (" + v + ")");
                 ok(setResult.hasOwnProperty("xhr"), "setResult has property: xhr (" + v + ")");
@@ -880,7 +886,10 @@
                     };
 
                 session[v].setAgentProfile(key, valFirst, options);
+                getResult = session[v].getAgentProfile(key, options);
+                options.lastSHA1 = getResult.profile.etag;
                 setResult = session[v].setAgentProfile(key, valUpdate, options);
+                delete options.lastSHA1;
 
                 ok(setResult.hasOwnProperty("err"), "setResult has property: err (" + v + ")");
                 ok(setResult.hasOwnProperty("xhr"), "setResult has property: xhr (" + v + ")");
@@ -928,7 +937,10 @@
                     };
 
                 session[v].setAgentProfile(key, valFirst, options);
+                getResult = session[v].getAgentProfile(key, options);
+                options.lastSHA1 = getResult.profile.etag;
                 setResult = session[v].setAgentProfile(key, valOverwrite, options);
+                delete options.lastSHA1;
 
                 ok(setResult.hasOwnProperty("err"), "setResult has property: err (" + v + ")");
                 ok(setResult.hasOwnProperty("xhr"), "setResult has property: xhr (" + v + ")");
@@ -939,7 +951,7 @@
                 deepEqual(getResult.profile.contents, valOverwrite, "getResult profile property contents (" + v + ")");
                 deepEqual(TinCan.Utils.getContentTypeFromHeader(getResult.profile.contentType), "application/json", "getResult profile property contentType (" + v + ")");
 
-                deleteResult = session[v].deleteAAgentProfile(key, options);
+                deleteResult = session[v].deleteAgentProfile(key, options);
             }
         );
     };
@@ -956,7 +968,7 @@
             doActivityProfileSyncContentTypeJSONTest(version);
             doAgentProfileSyncTest(version);
             doAgentProfileSyncContentTypeJSONTest(version);
-            if ((version ==! "0.95") && (version ==! "0.9")) {
+            if ((version !== "0.95") && (version !== "0.9")) {
                 doStateUpdateContentTest(version);
                 doStateOverwriteContentTest(version);
                 doActivityProfileUpdateContentTest(version);


### PR DESCRIPTION
Allow the AP to explicitly store a state document with no registration by passing a registration of null in the configuration.

Allow the AP to specify it wants to use POST instead of PUT for application/json.

Supersedes https://github.com/RusticiSoftware/TinCanJS/pull/93