### PR TITLE
round duration to centiseconds

### DIFF
--- a/src/Utils.js
+++ b/src/Utils.js
@@ -150,17 +150,21 @@ TinCan client library
                 minutes,
                 seconds,
                 i_inputMilliseconds = parseInt(inputMilliseconds, 10),
+                i_inputCentiseconds,
                 inputIsNegative = "",
                 rtnStr = "";
 
-            if (i_inputMilliseconds < 0) {
+            //round to nearest 0.01 seconds
+            i_inputCentiseconds = Math.round(i_inputMilliseconds / 10);
+
+            if (i_inputCentiseconds < 0) {
                 inputIsNegative = "-";
-                i_inputMilliseconds = i_inputMilliseconds * -1;
+                i_inputCentiseconds = i_inputCentiseconds * -1;
             }
 
-            hours = parseInt(((i_inputMilliseconds) / 3600000), 10);
-            minutes = parseInt((((i_inputMilliseconds) % 3600000) / 60000), 10);
-            seconds = (((i_inputMilliseconds) % 3600000) % 60000) / 1000;
+            hours = parseInt(((i_inputCentiseconds) / 360000), 10);
+            minutes = parseInt((((i_inputCentiseconds) % 360000) / 6000), 10);
+            seconds = (((i_inputCentiseconds) % 360000) % 6000) / 100;
 
             rtnStr = inputIsNegative + "PT";
             if (hours > 0) {

--- a/test/js/unit/Utils.js
+++ b/test/js/unit/Utils.js
@@ -67,7 +67,7 @@
     test(
         "convertMillisecondsToISO8601Duration",
         function () {
-            ok(TinCan.Utils.convertMillisecondsToISO8601Duration(5682475) === "PT1H34M42.475S", "return value");
+            ok(TinCan.Utils.convertMillisecondsToISO8601Duration(5682475) === "PT1H34M42.48S", "return value");
         }
     );
     test(


### PR DESCRIPTION
Utils.convertMillisecondsToISO8601Duration now returns a value rounded to 0.01 seconds. 

This PR **does not** include a build. 