### PR TITLE
Improve Utils.parseURL to handle relative URLs

### DIFF
--- a/src/LRS.js
+++ b/src/LRS.js
@@ -783,25 +783,24 @@ TinCan client library
 
             // to support our interface (to support IE) we need to break apart
             // the more URL query params so that the request can be made properly later
-            parsedURL = TinCan.Utils.parseURL(cfg.url);
+            parsedURL = TinCan.Utils.parseURL(cfg.url, { allowRelative: true });
 
-            //Respect a more URL that is relative to either the server root 
-            //or endpoint (though only the former is allowed in the spec)
+            // Respect a more URL that is relative to either the server root
+            // or endpoint (though only the former is allowed in the spec)
             serverRoot = TinCan.Utils.getServerRoot(this.endpoint);
             if (parsedURL.path.indexOf("/statements") === 0){
                 parsedURL.path = this.endpoint.replace(serverRoot, "") + parsedURL.path;
                 this.log("converting non-standard more URL to " + parsedURL.path);
             }
 
-            //The more relative URL might not start with a slash, add it if not
+            // The more relative URL might not start with a slash, add it if not
             if (parsedURL.path.indexOf("/") !== 0) {
                 parsedURL.path = "/" + parsedURL.path;
             }
 
             requestCfg = {
                 method: "GET",
-                //For arbitrary more URLs to work, 
-                //we need to make the URL absolute here
+                // For arbitrary more URLs to work, we need to make the URL absolute here
                 url: serverRoot + parsedURL.path,
                 params: parsedURL.params
             };

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -241,7 +241,7 @@ TinCan client library
         @return {Object} Object of values
         @private
         */
-        parseURL: function (url, options) {
+        parseURL: function (url, cfg) {
             //
             // see http://stackoverflow.com/a/21553982
             // and http://stackoverflow.com/a/2880929
@@ -260,7 +260,7 @@ TinCan client library
                 search = /([^&=]+)=?([^&]*)/g,
                 decode = function (s) { return decodeURIComponent(s.replace(pl, " ")); };
 
-            options = options || {};
+            cfg = cfg || {};
 
             //
             // this method in an earlier version supported relative URLs, mostly to provide
@@ -293,7 +293,7 @@ TinCan client library
                 //
                 // relative so make sure they allow that explicitly
                 //
-                if (typeof options.allowRelative === "undefined" || ! options.allowRelative) {
+                if (typeof cfg.allowRelative === "undefined" || ! cfg.allowRelative) {
                     throw new Error("Refusing to parse relative URL without 'allowRelative' option");
                 }
             }

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -236,15 +236,23 @@ TinCan client library
         /**
         @method parseURL
         @param {String} url
+        @param {Object} [options]
+            @param {Boolean} [options.allowRelative] Option to allow relative URLs
         @return {Object} Object of values
         @private
         */
-        parseURL: function (url) {
+        parseURL: function (url, options) {
             //
             // see http://stackoverflow.com/a/21553982
             // and http://stackoverflow.com/a/2880929
             //
-            var reURLInformation,
+            var isRelative = url.charAt(0) === "/",
+                _reURLInformation = [
+                    "(/[^?#]*)", // pathname
+                    "(\\?[^#]*|)", // search
+                    "(#.*|)$" // hash
+                ],
+                reURLInformation,
                 match,
                 result,
                 paramMatch,
@@ -252,29 +260,80 @@ TinCan client library
                 search = /([^&=]+)=?([^&]*)/g,
                 decode = function (s) { return decodeURIComponent(s.replace(pl, " ")); };
 
-            reURLInformation = new RegExp(
-                [
-                    "^(https?:)//", // protocol
-                    "(([^:/?#]*)(?::([0-9]+))?)", // host (hostname and port)
-                    "(/[^?#]*)", // pathname
-                    "(\\?[^#]*|)", // search
-                    "(#.*|)$" // hash
-                ].join("")
-            );
+            options = options || {};
+
+            //
+            // this method in an earlier version supported relative URLs, mostly to provide
+            // support to the `LRS.moreStatements` method, that functionality was removed and
+            // subsequently restored but with the addition of the option for allowing relative
+            // URLs to be accepted which is the reason for the "helpful" exception message here
+            //
+            if (! isRelative) {
+                //
+                // not relative so make sure they have a scheme, host, etc.
+                //
+                _reURLInformation.unshift(
+                    "^(https?:)//", // scheme
+                    "(([^:/?#]*)(?::([0-9]+))?)" // host (hostname and port)
+                );
+
+                //
+                // our regex requires there to be a '/' for the detection of the start
+                // of the path, we can detect a '/' using indexOf beyond the part of the
+                // scheme, since we've restricted scheme to 'http' or 'https' and because
+                // a hostname is guaranteed to be there we can detect beyond the '://'
+                // based on position, then tack on a trailing '/' because it can't be
+                // part of the path
+                //
+                if (url.indexOf("/", 8) === -1) {
+                    url = url + "/";
+                }
+            }
+            else {
+                //
+                // relative so make sure they allow that explicitly
+                //
+                if (typeof options.allowRelative === "undefined" || ! options.allowRelative) {
+                    throw new Error("Refusing to parse relative URL without 'allowRelative' option");
+                }
+            }
+
+            reURLInformation = new RegExp(_reURLInformation.join(""));
             match = url.match(reURLInformation);
-            result = {
-                protocol: match[1],
-                host: match[2],
-                hostname: match[3],
-                port: match[4],
-                pathname: match[5],
-                search: match[6],
-                hash: match[7],
-                params: {}
-            };
+            if (match === null) {
+                throw new Error("Unable to parse URL regular expression did not match: '" + url + "'");
+            }
 
             // 'path' is for backwards compatibility
-            result.path = result.protocol + "//" + result.host + result.pathname;
+            if (isRelative) {
+                result = {
+                    protocol: null,
+                    host: null,
+                    hostname: null,
+                    port: null,
+                    path: null,
+                    pathname: match[1],
+                    search: match[2],
+                    hash: match[3],
+                    params: {}
+                };
+
+                result.path = result.pathname;
+            }
+            else {
+                result = {
+                    protocol: match[1],
+                    host: match[2],
+                    hostname: match[3],
+                    port: match[4],
+                    pathname: match[5],
+                    search: match[6],
+                    hash: match[7],
+                    params: {}
+                };
+
+                result.path = result.protocol + "//" + result.host + result.pathname;
+            }
 
             if (result.search !== "") {
                 // extra parens to let jshint know this is an expression

--- a/test/js/unit/Utils.js
+++ b/test/js/unit/Utils.js
@@ -87,6 +87,108 @@
         function () {
             var result;
 
+            result = TinCan.Utils.parseURL("http://tincanapi.com");
+            deepEqual(
+                result,
+                {
+                    protocol: "http:",
+                    host: "tincanapi.com",
+                    hostname: "tincanapi.com",
+                    port: undefined,
+                    pathname: "/",
+                    search: "",
+                    hash: "",
+                    params: {},
+                    path: "http://tincanapi.com/"
+                },
+                "return value: basic URL no path"
+            );
+
+            result = TinCan.Utils.parseURL("https://tincanapi.com");
+            deepEqual(
+                result,
+                {
+                    protocol: "https:",
+                    host: "tincanapi.com",
+                    hostname: "tincanapi.com",
+                    port: undefined,
+                    pathname: "/",
+                    search: "",
+                    hash: "",
+                    params: {},
+                    path: "https://tincanapi.com/"
+                },
+                "return value: basic https URL no path"
+            );
+
+            result = TinCan.Utils.parseURL("http://tincanapi.com/");
+            deepEqual(
+                result,
+                {
+                    protocol: "http:",
+                    host: "tincanapi.com",
+                    hostname: "tincanapi.com",
+                    port: undefined,
+                    pathname: "/",
+                    search: "",
+                    hash: "",
+                    params: {},
+                    path: "http://tincanapi.com/"
+                },
+                "return value: basic URL empty path"
+            );
+
+            result = TinCan.Utils.parseURL("https://tincanapi.com/");
+            deepEqual(
+                result,
+                {
+                    protocol: "https:",
+                    host: "tincanapi.com",
+                    hostname: "tincanapi.com",
+                    port: undefined,
+                    pathname: "/",
+                    search: "",
+                    hash: "",
+                    params: {},
+                    path: "https://tincanapi.com/"
+                },
+                "return value: basic https URL empty path"
+            );
+
+            result = TinCan.Utils.parseURL("https://tincanapi.com/TinCanJS");
+            deepEqual(
+                result,
+                {
+                    protocol: "https:",
+                    host: "tincanapi.com",
+                    hostname: "tincanapi.com",
+                    port: undefined,
+                    pathname: "/TinCanJS",
+                    search: "",
+                    hash: "",
+                    params: {},
+                    path: "https://tincanapi.com/TinCanJS"
+                },
+                "return value: basic https URL simple path"
+            );
+
+            result = TinCan.Utils.parseURL("https://tincanapi.com/TinCanJS/");
+            deepEqual(
+                result,
+                {
+                    protocol: "https:",
+                    host: "tincanapi.com",
+                    hostname: "tincanapi.com",
+                    port: undefined,
+                    pathname: "/TinCanJS/",
+                    search: "",
+                    hash: "",
+                    params: {},
+                    path: "https://tincanapi.com/TinCanJS/"
+                },
+                "return value: basic https URL simple path with trailing slash"
+            );
+
             result = TinCan.Utils.parseURL("http://tincanapi.com:8080/TinCanJS/Test/TinCan.Utils_parseURL/test");
             deepEqual(
                 result,
@@ -164,6 +266,36 @@
                     path: "http://tincanapi.com:8080/TinCanJS/Test/TinCan.Utils_parseURL/test"
                 },
                 "return value: with params"
+            );
+
+            throws(
+                function () {
+                    result = TinCan.Utils.parseURL("/RelativeNotAllowed");
+                },
+                Error,
+                "relative without option"
+            );
+
+            result = TinCan.Utils.parseURL(
+                "/TinCanJS/Test/TinCan.Utils_parseURL/testRelative?paramA=1",
+                { allowRelative: true }
+            );
+            deepEqual(
+                result,
+                {
+                    protocol: null,
+                    host: null,
+                    hostname: null,
+                    port: null,
+                    pathname: "/TinCanJS/Test/TinCan.Utils_parseURL/testRelative",
+                    search: "?paramA=1",
+                    hash: "",
+                    params: {
+                        paramA: "1"
+                    },
+                    path: "/TinCanJS/Test/TinCan.Utils_parseURL/testRelative"
+                },
+                "return value: relative with params"
             );
         }
     );

--- a/test/js/unit/Utils.js
+++ b/test/js/unit/Utils.js
@@ -189,6 +189,40 @@
                 "return value: basic https URL simple path with trailing slash"
             );
 
+            result = TinCan.Utils.parseURL("http://localhost");
+            deepEqual(
+                result,
+                {
+                    protocol: "http:",
+                    host: "localhost",
+                    hostname: "localhost",
+                    port: undefined,
+                    pathname: "/",
+                    search: "",
+                    hash: "",
+                    params: {},
+                    path: "http://localhost/"
+                },
+                "return value: localhost URL no path"
+            );
+
+            result = TinCan.Utils.parseURL("http://localhost/TinCanJS/Test");
+            deepEqual(
+                result,
+                {
+                    protocol: "http:",
+                    host: "localhost",
+                    hostname: "localhost",
+                    port: undefined,
+                    pathname: "/TinCanJS/Test",
+                    search: "",
+                    hash: "",
+                    params: {},
+                    path: "http://localhost/TinCanJS/Test"
+                },
+                "return value: localhost URL"
+            );
+
             result = TinCan.Utils.parseURL("http://tincanapi.com:8080/TinCanJS/Test/TinCan.Utils_parseURL/test");
             deepEqual(
                 result,


### PR DESCRIPTION
This fixes more statement fetching, particularly as used by the prototypes identified by https://github.com/RusticiSoftware/TinCan_Prototypes/issues/36.