### PR TITLE
Fixed bug where content type header was undefined

### DIFF
--- a/src/LRS.js
+++ b/src/LRS.js
@@ -994,11 +994,11 @@ TinCan client library
                 requestHeaders;
 
             requestHeaders = cfg.requestHeaders || {};
-            requestHeaders["Content-Type"] = cfg.contentType;
 
             if (typeof cfg.contentType === "undefined") {
                 cfg.contentType = "application/octet-stream";
             }
+            requestHeaders["Content-Type"] = cfg.contentType;
 
             if (typeof val === "object" && TinCan.Utils.isApplicationJSON(cfg.contentType)) {
                 val = JSON.stringify(val);
@@ -1240,11 +1240,11 @@ TinCan client library
                 requestHeaders;
 
             requestHeaders = cfg.requestHeaders || {};
-            requestHeaders["Content-Type"] = cfg.contentType;
 
             if (typeof cfg.contentType === "undefined") {
                 cfg.contentType = "application/octet-stream";
             }
+            requestHeaders["Content-Type"] = cfg.contentType;
 
             if (typeof cfg.method === "undefined" || cfg.method !== "POST") {
                 cfg.method = "PUT";
@@ -1461,11 +1461,11 @@ TinCan client library
                 requestHeaders;
 
             requestHeaders = cfg.requestHeaders || {};
-            requestHeaders["Content-Type"] = cfg.contentType;
 
             if (typeof cfg.contentType === "undefined") {
                 cfg.contentType = "application/octet-stream";
             }
+            requestHeaders["Content-Type"] = cfg.contentType;
 
             if (typeof cfg.method === "undefined" || cfg.method !== "POST") {
                 cfg.method = "PUT";


### PR DESCRIPTION
In some cases, the content-type header was ending up undefined when it shouldn't.