### PR TITLE
Fixed version testing and expanded activity testing

### DIFF
--- a/src/TinCan.js
+++ b/src/TinCan.js
@@ -1255,6 +1255,7 @@ var TinCan;
     TinCan.versions = function () {
         // newest first so we can use the first as the default
         return [
+            "1.0.2",
             "1.0.1",
             "1.0.0",
             "0.95",

--- a/test/js/unit/Activity.js
+++ b/test/js/unit/Activity.js
@@ -32,4 +32,149 @@
             ok(result instanceof TinCan.Activity, "returns TinCan.Activity");
         }
     );
+
+    QUnit.module("Activity Instance");
+
+    test(
+        "activity Object",
+        function () {
+            var obj = new TinCan.Activity(),
+                nullProps = [
+                    "id",
+                    "definition"
+                ],
+                i
+            ;
+
+            ok(obj instanceof TinCan.Activity, "object is TinCan.Activity");
+
+            for (i = 0; i < nullProps.length; i += 1) {
+                ok(obj.hasOwnProperty(nullProps[i]), "object has property: " + nullProps[i]);
+                strictEqual(obj[nullProps[i]], null, "object property initial value: " + nullProps[i]);
+            }
+
+            strictEqual(obj.LOG_SRC, "Activity", "object property LOG_SRC initial value");
+            strictEqual(obj.objectType, "Activity", "object property objectType initial value");
+            strictEqual(obj.toString(), "Activity: unidentified", "object.toString unidentified");
+        }
+    );
+
+    test(
+        "activity variants",
+        function () {
+            var defined = new TinCan.ActivityDefinition(),
+                set = [
+                    {
+                        name: "activity with id",
+                        instanceConfig: {
+                            id: "http://TestActivity"
+                        },
+                        toString: "http://TestActivity",
+                        checkProps: {
+                            id: "http://TestActivity"
+                        }
+                    },
+                    {
+                        name: "activity with definition (basic definition)",
+                        instanceConfig: {
+                            id: "http://TestActivity",
+                            definition: defined
+                        },
+                        toString: "http://TestActivity",
+                        checkProps: {
+                            id: "http://TestActivity",
+                            definition: defined
+                        }
+                    },
+                    {
+                        name: "activity with definition (raw definition)",
+                        instanceConfig: {
+                            id: "http://TestActivity",
+                            definition: { name: "Test" }
+                        },
+                        toString: (new TinCan.ActivityDefinition({ name: "Test" })).toString(),
+                        checkProps: {
+                            id: "http://TestActivity",
+                            definition: new TinCan.ActivityDefinition({ name: "Test" })
+                        }
+                    }
+                ],
+                i,
+                obj
+            ;
+
+            for (i = 0; i < set.length; i += 1) {
+                row = set[i];
+                obj = new TinCan.Activity(row.instanceConfig);
+
+                ok(obj instanceof TinCan.Activity, "object is TinCan.Activity (" + row.name + ")");
+                strictEqual(obj.toString(), row.toString, "object.toString (" + row.name + ")");
+                if (typeof row.checkProps !== "undefined") {
+                    for (key in row.checkProps) {
+                        deepEqual(obj[key], row.checkProps[key], "object property initial value: " + key + " (" + row.name + ")");
+                    }
+                }
+            }
+        }
+    );
+
+    test(
+        "activity asVersion",
+        function () {
+            var set = [
+                    {
+                        name: "null field activity",
+                        instanceConfig: {},
+                        check: {
+                            id: null,
+                            objectType: "Activity"
+                        }
+                    },
+                    {
+                        name: "activity with id",
+                        instanceConfig: {
+                            id: "http://TestActivity"
+                        },
+                        check: {
+                            id: "http://TestActivity",
+                            objectType: "Activity"
+                        }
+                    },
+                    {
+                        name: "activity with definition",
+                        instanceConfig: {
+                            id: null,
+                            objectType: "Activity",
+                            definition: { name: "Test" }
+                        },
+                        check: {
+                            id: null,
+                            objectType: "Activity",
+                            definition: new TinCan.ActivityDefinition({ name: "Test" })
+                        }
+                    }
+                ],
+                versions = TinCan.versions(),
+                i,
+                v,
+                obj,
+                result
+            ;
+
+            for (i = 0; i < set.length; i += 1) {
+                row = set[i];
+                obj = new TinCan.Activity(row.instanceConfig);
+
+                if (!(row.instanceConfig.hasOwnProperty("definition"))) {
+                    deepEqual(obj.asVersion(), row.check, "object.asVersion() " + row.name);
+                }
+                else {
+                    for (v = 0; v < versions.length; v += 1) {
+                        result = obj.asVersion(versions[v]);
+                        deepEqual(result.definition, row.check.definition.asVersion(versions[v]), "object.asVersion() " + row.name + " : " + versions[v]);
+                    }
+                }
+            }
+        }
+    );
 }());

--- a/test/js/unit/LRS.js
+++ b/test/js/unit/LRS.js
@@ -187,12 +187,7 @@
     );
 
     (function () {
-        var versions = [
-                "1.0.1",
-                "1.0.0",
-                "0.95",
-                "0.9"
-            ],
+        var versions = TinCan.versions(),
             doAllowFailFalseAboutAsyncTest,
             doAllowFailTrueAboutAsyncTest,
             doAllowFailFalseAboutSyncTest,
@@ -229,7 +224,7 @@
                                     // Will break if suite is ran against a version not
                                     // supported by this library
                                     for (i = 0; i < xhr.version.length; i += 1) {
-                                        ok(TinCan.versions().indexOf(xhr.version[i]) !== -1,
+                                        ok(versions.indexOf(xhr.version[i]) !== -1,
                                             "callback: xhr.version has valid version (" + xhr.version[i] + ")");
                                     }
                                 }
@@ -284,7 +279,7 @@
                 // Will break if suite is ran against a version not
                 // supported by this library
                 for (i = 0; i < xhrversion.length; i += 1) {
-                    ok(TinCan.versions().indexOf(xhrversion[i]) !== -1,
+                    ok(versions.indexOf(xhrversion[i]) !== -1,
                         "about allowFail false: result.xhr.version has valid version [" + xhrversion[i] + "]");
                 }
             }

--- a/test/js/unit/TinCan.js
+++ b/test/js/unit/TinCan.js
@@ -39,7 +39,7 @@
     test(
         "TinCan.versions",
         function () {
-            deepEqual(TinCan.versions(), ["1.0.1", "1.0.0", "0.95", "0.9"], "Supported spec versions");
+            deepEqual(TinCan.versions(), ["1.0.2", "1.0.1", "1.0.0", "0.95", "0.9"], "Supported spec versions");
         }
     );
 


### PR DESCRIPTION
Version LRS async testing has been fixed for 1.0.2. New versions require updates in only two places now: the TinCan.versions() function and the test for it. All the basic version testing should update automatically. TinCanTestCfg has not been updated to 1.0.2.
Also, the full functionality of activities is now tested.