### PR TITLE
Added Attachments support for LRSs

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -3,6 +3,7 @@ module.exports = function(grunt) {
     "use strict";
     var coreFileList = [
         "vendor/cryptojs-v3.0.2/rollups/sha1.js",
+        "vendor/cryptojs-v3.0.2/rollups/sha256.js",
         "vendor/cryptojs-v3.0.2/components/enc-base64.js",
         "src/TinCan.js",
         "src/Utils.js",
@@ -25,7 +26,8 @@ module.exports = function(grunt) {
         "src/State.js",
         "src/ActivityProfile.js",
         "src/AgentProfile.js",
-        "src/About.js"
+        "src/About.js",
+        "src/Attachment.js"
     ],
     browserFileList = coreFileList.slice(),
     nodeFileList = coreFileList.slice(),

--- a/src/Attachment.js
+++ b/src/Attachment.js
@@ -1,5 +1,5 @@
 /*
-    Copyright 2014 Rustici Software
+    Copyright 2016 Rustici Software
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -72,6 +72,12 @@ TinCan client library
         */
         this.fileUrl = null;
 
+        /**
+        @property content
+        @type String
+        */
+        this.content = null;
+
         this.init(cfg);
     };
     Attachment.prototype = {
@@ -97,18 +103,13 @@ TinCan client library
                     "length",
                     "sha2",
                     "usageType",
-                    "display"
+                    "display",
+                    "description",
+                    "fileUrl"
                 ]
             ;
 
             cfg = cfg || {};
-
-            if (cfg.hasOwnProperty("description") && typeof cfg.description !== "undefined" && cfg.description !== null) {
-                this.description = cfg.description;
-            }
-            if (cfg.hasOwnProperty("fileUrl") && typeof cfg.fileUrl !== "undefined" && cfg.fileUrl !== null) {
-                this.fileUrl = cfg.fileUrl;
-            }
 
             for (i = 0; i < directProps.length; i += 1) {
                 if (cfg.hasOwnProperty(directProps[i]) && cfg[directProps[i]] !== null) {
@@ -116,7 +117,7 @@ TinCan client library
                 }
             }
 
-            if (cfg.hasOwnProperty("content") && typeof cfg.content !== "undefined" && cfg.content !== null) {
+            if (cfg.hasOwnProperty("content") && cfg.content !== null) {
                 this.content = cfg.content;
                 this.length = cfg.content.length;
                 this.sha2 = TinCan.Utils.getSHA256String(cfg.content);
@@ -139,15 +140,17 @@ TinCan client library
             else {
                 result = {
                     contentType: this.contentType,
-                    description: this.description,
                     display: this.display,
-                    fileUrl: this.fileUrl,
                     length: this.length,
                     sha2: this.sha2,
                     usageType: this.usageType
                 };
-                if (this.hasOwnProperty("content") && typeof this.content !== "undefined" && this.content !== null) {
-                    result.content = this.content;
+
+                if (this.fileUrl !== null) {
+                    result.fileUrl = this.fileUrl;
+                }
+                if (this.description !== null) {
+                    result.description = this.description;
                 }
             }
 

--- a/src/Attachment.js
+++ b/src/Attachment.js
@@ -1,0 +1,176 @@
+/*
+    Copyright 2014 Rustici Software
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+TinCan client library
+
+@module TinCan
+@submodule TinCan.Attachment
+**/
+(function () {
+    "use strict";
+
+    /**
+    @class TinCan.Attachment
+    @constructor
+    */
+    var Attachment = TinCan.Attachment = function (cfg) {
+        this.log("constructor");
+
+        /**
+        @property usageType
+        @type String
+        */
+        this.usageType = null;
+
+        /**
+        @property display
+        @type Object
+        */
+        this.display = null;
+
+        /**
+        @property contentType
+        @type String
+        */
+        this.contentType = null;
+
+        /**
+        @property length
+        @type int
+        */
+        this.length = null;
+
+        /**
+        @property sha2
+        @type String
+        */
+        this.sha2 = null;
+
+        /**
+        @property description
+        @type Object
+        */
+        this.description = null;
+
+        /**
+        @property fileUrl
+        @type String
+        */
+        this.fileUrl = null;
+
+        this.init(cfg);
+    };
+    Attachment.prototype = {
+        /**
+        @property LOG_SRC
+        */
+        LOG_SRC: "Attachment",
+
+        /**
+        @method log
+        */
+        log: TinCan.prototype.log,
+
+        /**
+        @method init
+        @param {Object} [options] Configuration used to initialize
+        */
+        init: function (cfg) {
+            this.log("init");
+            var i,
+                directProps = [
+                    "contentType",
+                    "length",
+                    "sha2",
+                    "usageType",
+                    "display"
+                ]
+            ;
+
+            cfg = cfg || {};
+
+            if (cfg.hasOwnProperty("description") && typeof cfg.description !== "undefined" && cfg.description !== null) {
+                this.description = cfg.description;
+            }
+            if (cfg.hasOwnProperty("fileUrl") && typeof cfg.fileUrl !== "undefined" && cfg.fileUrl !== null) {
+                this.fileUrl = cfg.fileUrl;
+            }
+
+            for (i = 0; i < directProps.length; i += 1) {
+                if (cfg.hasOwnProperty(directProps[i]) && cfg[directProps[i]] !== null) {
+                    this[directProps[i]] = cfg[directProps[i]];
+                }
+            }
+
+            if (cfg.hasOwnProperty("content") && typeof cfg.content !== "undefined" && cfg.content !== null) {
+                this.content = cfg.content;
+                this.length = cfg.content.length;
+                this.sha2 = TinCan.Utils.getSHA256String(cfg.content);
+            }
+        },
+
+        /**
+        @method asVersion
+        @param {String} [version] Version to return (defaults to newest supported)
+        */
+        asVersion: function (version) {
+            this.log("asVersion");
+            var result;
+
+            version = version || TinCan.versions()[0];
+
+            if (version === "0.9" || version === "0.95") {
+                result = null;
+            }
+            else {
+                result = {
+                    contentType: this.contentType,
+                    description: this.description,
+                    display: this.display,
+                    fileUrl: this.fileUrl,
+                    length: this.length,
+                    sha2: this.sha2,
+                    usageType: this.usageType
+                };
+                if (this.hasOwnProperty("content") && typeof this.content !== "undefined" && this.content !== null) {
+                    result.content = this.content;
+                }
+            }
+
+            return result;
+        },
+
+        /**
+        See {{#crossLink "TinCan.Utils/getLangDictionaryValue"}}{{/crossLink}}
+
+        @method getLangDictionaryValue
+        */
+        getLangDictionaryValue: TinCan.Utils.getLangDictionaryValue
+    };
+
+    /**
+    @method fromJSON
+    @return {Object} Attachment
+    @static
+    */
+    Attachment.fromJSON = function (attachmentJSON) {
+        Attachment.prototype.log("fromJSON");
+        var _attachment = JSON.parse(attachmentJSON);
+
+        return new Attachment(_attachment);
+    };
+}());

--- a/src/Statement.js
+++ b/src/Statement.js
@@ -186,8 +186,7 @@ TinCan client library
                     "version",
                     "inProgress",
                     "voided"
-                ],
-                a;
+                ];
 
             cfg = cfg || {};
 
@@ -286,13 +285,14 @@ TinCan client library
                     this.context = new TinCan.Context (cfg.context);
                 }
             }
-            if (cfg.hasOwnProperty("attachments") && cfg.attachments !== null && typeof cfg.attachments !== "undefined") {
+            if (cfg.hasOwnProperty("attachments") && cfg.attachments !== null) {
                 this.attachments = [];
-                for (a = 0; a < cfg.attachments.length; a += 1) {
-                    if (!(cfg.attachments[a] instanceof TinCan.Attachment)) {
-                        this.attachments.push(new TinCan.Attachment (cfg.attachments[a]));
-                    } else {
-                        this.attachments.push(cfg.attachments[a]);
+                for (i = 0; i < cfg.attachments.length; i += 1) {
+                    if (! (cfg.attachments[i] instanceof TinCan.Attachment)) {
+                        this.attachments.push(new TinCan.Attachment (cfg.attachments[i]));
+                    }
+                    else {
+                        this.attachments.push(cfg.attachments[i]);
                     }
                 }
             }
@@ -339,9 +339,7 @@ TinCan client library
                     "context",
                     "authority"
                 ],
-                a,
-                i,
-                temp;
+                i;
 
             version = version || TinCan.versions()[0];
 
@@ -368,15 +366,14 @@ TinCan client library
                 result.inProgress = this.inProgress;
             }
             if (this.attachments !== null) {
-                if (!(version === "0.9" || version === "0.95")) {
+                if (! (version === "0.9" || version === "0.95")) {
                     result.attachments = [];
-                    for (a = 0; a < this.attachments.length; a += 1) {
-                        if (this.attachments[a] instanceof TinCan.Attachment) {
-                            result.attachments.push(this.attachments[a].asVersion(version));
+                    for (i = 0; i < this.attachments.length; i += 1) {
+                        if (this.attachments[i] instanceof TinCan.Attachment) {
+                            result.attachments.push(this.attachments[i].asVersion(version));
                         }
                         else {
-                            temp = new TinCan.Attachment(this.attachments[a]);
-                            result.attachments.push(temp.asVersion(version));
+                            result.attachments.push(new TinCan.Attachment(this.attachments[i]).asVersion(version));
                         }
                     }
                 }
@@ -398,6 +395,29 @@ TinCan client library
             if (this.timestamp === null) {
                 this.timestamp = TinCan.Utils.getISODateString(new Date());
             }
+        },
+
+        /**
+        Checks if the Statement has at least one attachment with content
+
+        @method hasAttachmentsWithContent
+        */
+        hasAttachmentWithContent: function () {
+            this.log("hasAttachmentWithContent");
+            var i;
+
+            if (! this.hasOwnProperty("attachments")) {
+                return false;
+            }
+            else {
+                for (i = 0; i < this.attachments.length; i += 1) {
+                    if (this.attachments[i].hasOwnProperty("content") && this.attachments[i].content !== null) {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
         }
     };
 

--- a/src/Statement.js
+++ b/src/Statement.js
@@ -35,6 +35,7 @@ TinCan client library
         @param {TinCan.Result} [cfg.result] Statement Result
         @param {TinCan.Context} [cfg.context] Statement Context
         @param {TinCan.Agent} [cfg.authority] Statement Authority
+        @param {TinCan.Attachment} [cfg.attachments] Statement Attachments
         @param {String} [cfg.timestamp] ISO8601 Date/time value
         @param {String} [cfg.stored] ISO8601 Date/time value
         @param {String} [cfg.version] Version of the statement (post 0.95)
@@ -117,6 +118,12 @@ TinCan client library
         this.authority = null;
 
         /**
+        @property attachments
+        @type Array of TinCan.Attachment
+        */
+        this.attachments = null;
+
+        /**
         @property version
         @type String
         */
@@ -179,7 +186,8 @@ TinCan client library
                     "version",
                     "inProgress",
                     "voided"
-                ];
+                ],
+                a;
 
             cfg = cfg || {};
 
@@ -278,6 +286,16 @@ TinCan client library
                     this.context = new TinCan.Context (cfg.context);
                 }
             }
+            if (cfg.hasOwnProperty("attachments") && cfg.attachments !== null && typeof cfg.attachments !== "undefined") {
+                this.attachments = [];
+                for (a = 0; a < cfg.attachments.length; a += 1) {
+                    if (!(cfg.attachments[a] instanceof TinCan.Attachment)) {
+                        this.attachments.push(new TinCan.Attachment (cfg.attachments[a]));
+                    } else {
+                        this.attachments.push(cfg.attachments[a]);
+                    }
+                }
+            }
 
             for (i = 0; i < directProps.length; i += 1) {
                 if (cfg.hasOwnProperty(directProps[i]) && cfg[directProps[i]] !== null) {
@@ -321,7 +339,9 @@ TinCan client library
                     "context",
                     "authority"
                 ],
-                i;
+                a,
+                i,
+                temp;
 
             version = version || TinCan.versions()[0];
 
@@ -346,6 +366,20 @@ TinCan client library
             }
             if (version === "0.9" && this.inProgress !== null) {
                 result.inProgress = this.inProgress;
+            }
+            if (this.attachments !== null) {
+                if (!(version === "0.9" || version === "0.95")) {
+                    result.attachments = [];
+                    for (a = 0; a < this.attachments.length; a += 1) {
+                        if (this.attachments[a] instanceof TinCan.Attachment) {
+                            result.attachments.push(this.attachments[a].asVersion(version));
+                        }
+                        else {
+                            temp = new TinCan.Attachment(this.attachments[a]);
+                            result.attachments.push(temp.asVersion(version));
+                        }
+                    }
+                }
             }
 
             return result;

--- a/src/Statement.js
+++ b/src/Statement.js
@@ -411,7 +411,7 @@ TinCan client library
             }
             else {
                 for (i = 0; i < this.attachments.length; i += 1) {
-                    if (this.attachments[i].hasOwnProperty("content") && this.attachments[i].content !== null) {
+                    if (this.attachments[i].content !== null) {
                         return true;
                     }
                 }

--- a/src/TinCan.js
+++ b/src/TinCan.js
@@ -448,16 +448,22 @@ var TinCan;
         Calls retrieveStatement on the first LRS, provide callback to make it asynchronous
 
         @method getStatement
-        @param {String} statement Statement ID to get
+        @param {String} [stmtId] Statement ID to get
         @param {Function} [callback] Callback function to execute on completion
+        @param {Object} [cfg] Configuration data
+            @param {Object} [params] Query parameters
+                @param {Boolean} [attachments] Include attachments in multipart response or don't (defualt: false)
         @return {Array|Result} Array of results, or single result
 
         TODO: make TinCan track statements it has seen in a local cache to be returned easily
         */
-        getStatement: function (stmtId, callback) {
+        getStatement: function (stmtId, callback, cfg) {
             this.log("getStatement");
 
             var lrs;
+
+            cfg = cfg || {};
+            cfg.params = cfg.params || {};
 
             if (this.recordStores.length > 0) {
                 //
@@ -471,7 +477,7 @@ var TinCan;
                 //
                 lrs = this.recordStores[0];
 
-                return lrs.retrieveStatement(stmtId, { callback: callback });
+                return lrs.retrieveStatement(stmtId, { callback: callback, params: cfg.params });
             }
 
             this.log("[warning] getStatement: No LRSs added yet (statement not retrieved)");

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -383,16 +383,6 @@ TinCan client library
         },
 
         /**
-        @method getXAPIHashFromHeader
-        @static
-        @param {String} X-Experience-API-Hash header value
-        @return {String} Primary value from X-Experience-API-Hash
-        */
-        getXAPIHashFromHeader: function (header) {
-            return (String(header).split(":"))[1].replace(/^\s+|\s+$/g,"");
-        },
-
-        /**
         @method isApplicationJSON
         @static
         @param {String} Content-Type header value

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -383,6 +383,16 @@ TinCan client library
         },
 
         /**
+        @method getXAPIHashFromHeader
+        @static
+        @param {String} X-Experience-API-Hash header value
+        @return {String} Primary value from X-Experience-API-Hash
+        */
+        getXAPIHashFromHeader: function (header) {
+            return (String(header).split(":"))[1].replace(/^\s+|\s+$/g,"");
+        },
+
+        /**
         @method isApplicationJSON
         @static
         @param {String} Content-Type header value

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -193,6 +193,18 @@ TinCan client library
         },
 
         /**
+        @method getSHA256String
+        @static
+        @param {String} str Content to hash
+        @return {String} SHA256 for contents
+        */
+        getSHA256String: function (str) {
+            /*global CryptoJS*/
+
+            return CryptoJS.SHA256(str).toString(CryptoJS.enc.Hex);
+        },
+
+        /**
         @method getBase64String
         @static
         @param {String} str Content to encode

--- a/test/complete.html
+++ b/test/complete.html
@@ -16,6 +16,8 @@
 -->
 <html>
 <head>
+    <meta content="text/html;charset=utf-8" http-equiv="Content-Type">
+    <meta content="utf-8" http-equiv="encoding">
     <title>TinCanJS Tests</title>
     <!-- TODO: we should really try to use SinonJS -->
     <link rel="stylesheet" href="vendor/qunit-1.10.0pre.css" type="text/css" media="screen" />
@@ -60,5 +62,6 @@
     <script src="js/unit/LRS.js"></script>
     <script src="js/unit/LRS-browser.js"></script>
     <script src="js/unit/About.js"></script>
+    <script src="js/unit/Attachment.js"></script>
 </body>
 </html>

--- a/test/index.html
+++ b/test/index.html
@@ -51,6 +51,7 @@
         <li><a href="single/SubStatement.html">SubStatement</a></li>
         <li><a href="single/Verb.html">Verb</a></li>
         <li><a href="single/Utils.html">Utils</a></li>
+        <li><a href="single/Attachment.html">Attachment</a></li>
     </ul>
 
     <h2>Special Conditions</h2>

--- a/test/js/unit/Attachment.js
+++ b/test/js/unit/Attachment.js
@@ -1,0 +1,167 @@
+/*
+    Copyright 2014 Rustici Software
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+(function () {
+    var session = null;
+
+    QUnit.module("Attachment Statics");
+
+    test(
+        "Attachment.fromJSON",
+        function () {
+            var raw = {
+                    usageType: "http://id.tincanapi.com/attachment/test-attachment"
+                },
+                string,
+                result;
+
+            result = TinCan.Attachment.fromJSON(JSON.stringify(raw));
+            ok(result instanceof TinCan.Attachment, "returns TinCan.Attachment");
+        }
+    );
+
+    QUnit.module("Attachment Instance");
+
+    test(
+        "attachment Object",
+        function () {
+            var obj = new TinCan.Attachment(),
+                nullProps = [
+                    "usageType",
+                    "display",
+                    "contentType",
+                    "length",
+                    "sha2",
+                    "description",
+                    "fileUrl"
+                ],
+                i
+            ;
+            ok(obj instanceof TinCan.Attachment, "object is TinCan.Attachment");
+
+            for(i = 0; i < nullProps.length; i += 1) {
+                ok(obj.hasOwnProperty(nullProps[i]), "object has property: " + nullProps[i]);
+                strictEqual(obj[nullProps[i]], null, "object property initial value: " + nullProps[i]);
+            }
+
+            strictEqual(obj.LOG_SRC, "Attachment", "object property LOG_SRC initial value");
+            //strictEqual(obj.objectType, "Attachment", "object property objectType initial value");
+        }
+    );
+
+    test(
+        "attachment variants",
+        function () {
+            var set = [
+                {
+                    name: "Attachment with usageType",
+                    instanceConfig: {
+                        usageType: "http://id.tincanapi.com/attachment/test-attachment"
+                    },
+                    checkProps: {
+                        usageType: "http://id.tincanapi.com/attachment/test-attachment"
+                    }
+                },
+                {
+                    name: "Attachment with display",
+                    instanceConfig: {
+                        display: {
+                            "en-US": "Test-Attachment"
+                        }
+                    },
+                    checkProps: {
+                        display: {
+                            "en-US": "Test-Attachment"
+                        }
+                    }
+                },
+                {
+                    name: "Attachment with contentType",
+                    instanceConfig: {
+                        contentType: "attachment/test"
+                    },
+                    checkProps: {
+                        contentType: "attachment/test"
+                    }
+                },
+                {
+                    name: "Attachment with length",
+                    instanceConfig: {
+                        length: 7357
+                    },
+                    checkProps: {
+                        length: 7357
+                    }
+                },
+                {
+                    name: "Attachment with sha2",
+                    instanceConfig: {
+                        sha2: "arbitrary"
+                    },
+                    checkProps: {
+                        sha2: "arbitrary"
+                    }
+                },
+                {
+                    name: "Attachment with description",
+                    instanceConfig: {
+                        description: {
+                            "en-US": "arbitrary"
+                        }
+                    },
+                    checkProps: {
+                        description: {
+                            "en-US": "arbitrary"
+                        }
+                    }
+                },
+                {
+                    name: "Attachment with fileUrl",
+                    instanceConfig: {
+                        fileUrl: "http://id.tincanapi.com/attachment/test-attachment.pdf"
+                    },
+                    checkProps: {
+                        fileUrl: "http://id.tincanapi.com/attachment/test-attachment.pdf"
+                    }
+                },
+                {
+                    name: "Attachment with content",
+                    instanceConfig: {
+                        content: "test text content"
+                    },
+                    checkProps: {
+                        content: "test text content"
+                    }
+                }
+            ],
+                i,
+                obj,
+                result
+            ;
+
+            for (i = 0; i < set.length; i += 1) {
+                row = set[i];
+                obj = new TinCan.Attachment(row.instanceConfig);
+
+                ok(obj instanceof TinCan.Attachment, "object is TinCan.Attachment (" + row.name + ")");
+                if (typeof row.checkProps !== "undefined") {
+                    for (key in row.checkProps) {
+                        deepEqual(obj[key], row.checkProps[key], "object property initial value: " + key + " (" + row.name + ")");
+                    }
+                }
+            }
+        }
+    )
+}());

--- a/test/js/unit/Attachment.js
+++ b/test/js/unit/Attachment.js
@@ -1,5 +1,5 @@
 /*
-    Copyright 2014 Rustici Software
+    Copyright 2016 Rustici Software
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -57,7 +57,6 @@
             }
 
             strictEqual(obj.LOG_SRC, "Attachment", "object property LOG_SRC initial value");
-            //strictEqual(obj.objectType, "Attachment", "object property objectType initial value");
         }
     );
 
@@ -146,10 +145,9 @@
                     }
                 }
             ],
-                i,
-                obj,
-                result
-            ;
+            i,
+            obj,
+            result;
 
             for (i = 0; i < set.length; i += 1) {
                 row = set[i];

--- a/test/js/unit/LRS.js
+++ b/test/js/unit/LRS.js
@@ -197,9 +197,10 @@
                 val,
                 list = [],
                 seen = {},
-                noDupe = true;
+                noDupe = true,
+                lrs = new TinCan.LRS({ endpoint: endpoint });
             for (i = 0; i < 500; i += 1) {
-                val = TinCan.LRS.prototype._getBoundary();
+                val = lrs._getBoundary();
                 ok(re.test(val), "formatted correctly: " + i);
 
                 list.push(val);
@@ -216,15 +217,17 @@
     test(
         "_createStatementSegment",
         function () {
-            var testString = "--testBoundary\r\nContent-Type: application/json\r\n\r\n\"test\"\r\n";
-            deepEqual(TinCan.LRS.prototype._createStatementSegment("testBoundary", "test"), testString, "Statement segment created correctly");
+            var testString = "--testBoundary\r\nContent-Type: application/json\r\n\r\n\"test\"\r\n",
+                lrs = new TinCan.LRS({ endpoint: endpoint });
+            deepEqual(lrs._createStatementSegment("testBoundary", "test"), testString, "Statement segment created correctly");
         }
     );
     test(
         "_createAttachmentSegment",
         function () {
-            var testString = "--testBoundary\r\nContent-Type: text/plain\r\nContent-Transfer-Encoding: binary\r\nX-Experience-API-Hash: testHash\r\n\r\ntest\r\n";
-            deepEqual(TinCan.LRS.prototype._createAttachmentSegment("testBoundary", "test", "testHash", "text/plain"), testString, "Statement segment created correctly");
+            var testString = "--testBoundary\r\nContent-Type: text/plain\r\nContent-Transfer-Encoding: binary\r\nX-Experience-API-Hash: testHash\r\n\r\ntest\r\n",
+                lrs = new TinCan.LRS({ endpoint: endpoint });
+            deepEqual(lrs._createAttachmentSegment("testBoundary", "test", "testHash", "text/plain"), testString, "Statement segment created correctly");
         }
     );
 

--- a/test/js/unit/LRS.js
+++ b/test/js/unit/LRS.js
@@ -189,6 +189,45 @@
 
     QUnit.module("LRS method calls");
 
+    test(
+        "_getBoundary",
+        function () {
+            var re = /[a-f0-9]{8}[a-f0-9]{4}4[a-f0-9]{3}[89ab][a-f0-9]{3}[a-f0-9]{12}/,
+                i,
+                val,
+                list = [],
+                seen = {},
+                noDupe = true;
+            for (i = 0; i < 500; i += 1) {
+                val = TinCan.LRS.prototype._getBoundary();
+                ok(re.test(val), "formatted correctly: " + i);
+
+                list.push(val);
+            }
+            for (i = 0; i < 500; i += 1) {
+                if (seen.hasOwnProperty(list[i])) {
+                    noDupe = false;
+                }
+                seen[list[i]] = true;
+            }
+            ok(noDupe, "no duplicates in 500");
+        }
+    );
+    test(
+        "_createStatementSegment",
+        function () {
+            var testString = "--testBoundary\r\nContent-Type: application/json\r\n\r\n\"test\"\r\n";
+            deepEqual(TinCan.LRS.prototype._createStatementSegment("testBoundary", "test"), testString, "Statement segment created correctly");
+        }
+    );
+    test(
+        "_createAttachmentSegment",
+        function () {
+            var testString = "--testBoundary\r\nContent-Type: text/plain\r\nContent-Transfer-Encoding: binary\r\nX-Experience-API-Hash: testHash\r\n\r\ntest\r\n";
+            deepEqual(TinCan.LRS.prototype._createAttachmentSegment("testBoundary", "test", "testHash", "text/plain"), testString, "Statement segment created correctly");
+        }
+    );
+
     (function () {
         var versions = TinCan.versions(),
             doAsyncStateTest,

--- a/test/js/unit/Statement.js
+++ b/test/js/unit/Statement.js
@@ -75,7 +75,7 @@
                 context = new TinCan.Context(),
                 authority = new TinCan.Agent({ mbox: "tincanjs-test-authority@tincanapi.com" }),
                 attachments = [
-                        new TinCan.Attachment({ usageType: "http://id.tincanapi.com/attachment/test-attachment" })
+                    new TinCan.Attachment({ usageType: "http://id.tincanapi.com/attachment/test-attachment" })
                 ],
                 set = [
                     {
@@ -150,7 +150,7 @@
                                 timestamp: timestamp,
                                 authority: { objectType: "Agent", mbox: "mailto:tincanjs-test-authority@tincanapi.com" },
                                 attachments: [
-                                    { contentType: null, description: null, display: null, fileUrl: null, length: null, sha2: null, usageType: "http://id.tincanapi.com/attachment/test-attachment" }
+                                    { contentType: null, display: null, length: null, sha2: null, usageType: "http://id.tincanapi.com/attachment/test-attachment" }
                                 ]
                             },
                             "0.95": {

--- a/test/js/unit/Statement.js
+++ b/test/js/unit/Statement.js
@@ -74,6 +74,9 @@
                 result = new TinCan.Result(),
                 context = new TinCan.Context(),
                 authority = new TinCan.Agent({ mbox: "tincanjs-test-authority@tincanapi.com" }),
+                attachments = [
+                        new TinCan.Attachment({ usageType: "http://id.tincanapi.com/attachment/test-attachment" })
+                ],
                 set = [
                     {
                         name: "empty",
@@ -91,6 +94,7 @@
                             timestamp: null,
                             stored: null,
                             authority: null,
+                            attachments: null,
                             version: null,
                             degraded: false,
                             voided: null,
@@ -112,6 +116,7 @@
                             timestamp: timestamp,
                             stored: timestamp,
                             authority: authority,
+                            attachments: attachments,
                             version: "1.0.0",
 
                             // deprecated
@@ -128,6 +133,7 @@
                             timestamp: timestamp,
                             stored: timestamp,
                             authority: authority,
+                            attachments: attachments,
                             version: "1.0.0",
                             degraded: false,
                             voided: false,
@@ -142,7 +148,10 @@
                                 result: {},
                                 context: {},
                                 timestamp: timestamp,
-                                authority: { objectType: "Agent", mbox: "mailto:tincanjs-test-authority@tincanapi.com" }
+                                authority: { objectType: "Agent", mbox: "mailto:tincanjs-test-authority@tincanapi.com" },
+                                attachments: [
+                                    { contentType: null, description: null, display: null, fileUrl: null, length: null, sha2: null, usageType: "http://id.tincanapi.com/attachment/test-attachment" }
+                                ]
                             },
                             "0.95": {
                                 id: uuid,
@@ -182,7 +191,6 @@
                 row.instanceInitConfig = row.instanceInitConfig || {};
 
                 obj = new TinCan.Statement (row.instanceConfig, row.instanceInitConfig);
-
                 ok(obj instanceof TinCan.Statement, "object is TinCan.Statement (" + row.name + ")");
                 if (typeof row.checkProps !== "undefined") {
                     for (key in row.checkProps) {

--- a/test/js/unit/TinCan-async.js
+++ b/test/js/unit/TinCan-async.js
@@ -157,6 +157,68 @@
         );
     };
 
+    doSendStatementWithAttachmentTest = function (v) {
+        asyncTest(
+            "sendStatementWithAttachment (prepared, async): " + v,
+            function () {
+                var preparedStmt,
+                    sendResult,
+                    //
+                    // Cloud is lowercasing the mbox value so just use a lowercase one
+                    // and make sure it is unique to prevent merging that was previously
+                    // possible, but leaving the commented version as a marker for something
+                    // that ought to be tested against a 1.0.0 spec
+                    //
+                    //actorMbox = "mailto:TinCanJS-test-TinCan+" + Date.now() + "@tincanapi.com";
+                    actorMbox = "mailto:tincanjs-test-tincan+" + Date.now() + "@tincanapi.com";
+
+                preparedStmt = session[v].prepareStatement(
+                    {
+                        actor: {
+                            mbox: actorMbox
+                        },
+                        verb: {
+                            id: "http://adlnet.gov/expapi/verbs/attempted"
+                        },
+                        target: {
+                            id: "http://tincanapi.com/TinCanJS/Test/TinCan_sendStatement/async/" + v
+                        },
+                        attachments: [
+                            {
+                                display: {
+                                    "en-US": "Test Attachment"
+                                },
+                                usageType: "http://id.tincanapi.com/attachment/test-attachment",
+                                content: "test content",
+                                contentType: "text/plain"
+                            }
+                        ]
+                    }
+                );
+                sendResult = session[v].sendStatement(
+                    preparedStmt,
+                    function (results, statement) {
+                        start();
+                        ok(results.length === 1, "callback results argument: length (" + v + ")");
+                        ok(results[0].hasOwnProperty("err"), "callback results argument 0 has property: err (" + v + ")");
+                        deepEqual(results[0].err, null, "callback results argument 0 property value: err (" + v + ")");
+                        ok(results[0].hasOwnProperty("xhr"), "callback results argument 0 has property: xhr (" + v + ")");
+                        TinCanTest.assertHttpRequestType(results[0].xhr, "callback results argument 0 property value: xhr (" + v + ")");
+                        deepEqual(statement, preparedStmt, "callback: statement matches (" + v + ")");
+                    }
+                );
+                start();
+                ok(sendResult.hasOwnProperty("statement"), "sendResult has property: statement (" + v + ")");
+                deepEqual(preparedStmt, sendResult.statement, "sendResult property value: statement (" + v + ")");
+
+                ok(sendResult.hasOwnProperty("results"), "sendResult has property: results (" + v + ")");
+                strictEqual(sendResult.results.length, 1, "sendResult results property: length (" + v + ")");
+                TinCanTest.assertHttpRequestType(sendResult.results[0], "sendResult results 0 value is: xhr (" + v + ")");
+                stop();
+            }
+        );
+    };
+
     doGetStatementAsyncTest = function (v) {
         asyncTest(
             "getStatement (async): " + v,
@@ -180,7 +242,7 @@
                             id: "http://adlnet.gov/expapi/verbs/attempted"
                         },
                         target: {
-                            id: "http://tincanapi.com/TinCanJS/Test/TinCan_getStatement/async/" + v
+                            id: "http://tincanapi.com/TinCanJS/Test/TinCan_getStatements/async/" + v
                         }
                     },
                     function (results, sentStatement) {
@@ -243,6 +305,7 @@
                 //actorMbox = "mailto:TinCanJS-test-TinCan+" + Date.now() + "@tincanapi.com";
                 actorMbox = "mailto:tincanjs-test-tincan+" + Date.now() + "@tincanapi.com";
 
+
                 sendResult = session[v].sendStatement(
                     {
                         actor: {
@@ -254,6 +317,7 @@
                         target: {
                             id: "http://tincanapi.com/TinCanJS/Test/TinCan_getStatement/async/" + v
                         }
+
                     },
                     function (results, sentStatement) {
                         // TODO: need to handle errors?
@@ -272,6 +336,7 @@
                         );
                     }
                 );
+
             }
         );
     };
@@ -290,6 +355,7 @@
                 //actorMbox = "mailto:TinCanJS-test-TinCan+" + Date.now() + "@tincanapi.com";
                 actorMbox = "mailto:tincanjs-test-tincan+" + Date.now() + "@tincanapi.com";
 
+
                 sendResult = session[v].sendStatement(
                     {
                         actor: {
@@ -301,6 +367,7 @@
                         target: {
                             id: "http://tincanapi.com/TinCanJS/Test/TinCan_getStatement/async/" + v
                         }
+
                     },
                     function (results, sentStatement) {
                         // TODO: need to handle errors?
@@ -309,11 +376,13 @@
                             {
                                 params: {
                                     activity: "http://tincanapi.com/TinCanJS/Test/TinCan_getStatement/async/" + v
+
                                 },
                                 callback: function (err, statement) {
                                     start();
                                     deepEqual(err, null, "callback: err argument (" + v + ")");
                                     deepEqual(sentStatement.target.id, statement.statements[0].target.id, "callback: statement verb id matches (" + v + ")");
+
                                 }
                             }
                         );
@@ -323,16 +392,141 @@
         );
     };
 
+    doGetStatementWithAttachmentTest = function (v) {
+        asyncTest(
+            "getStatementWithAttachment (async): " + v,
+            function () {
+                var sendResult,
+                    //
+                    // Cloud is lowercasing the mbox value so just use a lowercase one
+                    // and make sure it is unique to prevent merging that was previously
+                    // possible, but leaving the commented version as a marker for something
+                    // that ought to be tested against a 1.0.0 spec
+                    //
+                    //actorMbox = "mailto:TinCanJS-test-TinCan+" + Date.now() + "@tincanapi.com";
+                    actorMbox = "mailto:tincanjs-test-tincan+" + Date.now() + "@tincanapi.com";
+
+                sendResult = session[v].sendStatement(
+                    {
+                        actor: {
+                            mbox: actorMbox
+                        },
+                        verb: {
+                            id: "http://adlnet.gov/expapi/verbs/attempted"
+                        },
+                        target: {
+                            id: "http://tincanapi.com/TinCanJS/Test/TinCan_getStatementWithAttachment/async/" + v
+                        },
+                        attachments: [
+                            {
+                                display: {
+                                    "en-US": "Test Attachment"
+                                },
+                                usageType: "http://id.tincanapi.com/attachment/test-attachment",
+                                content: "test content",
+                                contentType: "text/plain"
+                            }
+                        ]
+                    },
+                    function (results, sentStatement) {
+                        // TODO: need to handle errors?
+
+                        var getResult = session[v].getStatement(
+                            sentStatement.id,
+                            function (err, statement) {
+                                start();
+
+                                // clear the "stored" and "authority" properties since we couldn't have known them ahead of time
+                                // TODO: should we check the authority?
+                                statement.stored = null;
+                                statement.authority = null;
+
+                                deepEqual(err, null, "callback: err argument (" + v + ")");
+                                deepEqual(sentStatement.attachments[0], statement.attachments[0], "callback: statement matches (" + v + ")");
+                            },
+                            {
+                                params: {
+                                    attachments: true
+                                }
+                            }
+                        );
+                        // TODO: check getResult is an XHR?
+                    }
+                );
+                // TODO: check return value?
+            }
+        );
+    };
+
+    doGetStatementsWithAttachmentTest = function (v) {
+        asyncTest(
+            "getStatementsWithAttachment (async): " + v,
+            function () {
+                var sendResult,
+                    //
+                    // Cloud is lowercasing the mbox value so just use a lowercase one
+                    // and make sure it is unique to prevent merging that was previously
+                    // possible, but leaving the commented version as a marker for something
+                    // that ought to be tested against a 1.0.0 spec
+                    //
+                    //actorMbox = "mailto:TinCanJS-test-TinCan+" + Date.now() + "@tincanapi.com";
+                    actorMbox = "mailto:tincanjs-test-tincan+" + Date.now() + "@tincanapi.com";
+
+                sendResult = session[v].sendStatement(
+                    {
+                        actor: {
+                            mbox: actorMbox
+                        },
+                        verb: {
+                            id: "http://adlnet.gov/expapi/verbs/attempted"
+                        },
+                        target: {
+                            id: "http://tincanapi.com/TinCanJS/Test/TinCan_getStatementsWithAttachment/async/" + v
+                        },
+                        attachments: [
+                            {
+                                display: {
+                                    "en-US": "Test Attachment"
+                                },
+                                usageType: "http://id.tincanapi.com/attachment/test-attachment",
+                                content: "test content",
+                                contentType: "text/plain"
+                            }
+                        ]
+                    },
+                    function (results, sentStatement) {
+                        // TODO: need to handle errors?
+
+                        var getResult = session[v].getStatements(
+                            {
+                                params: {
+                                    attachments: true
+                                },
+                                callback: function (err, statement) {
+                                    start();
+                                    deepEqual(err, null, "callback: err argument (" + v + ")");
+                                    deepEqual(sentStatement.attachments[0], statement.statements[0].attachments[0], "callback: statement matches (" + v + ")");
+                                }
+                            }
+                        );
+                    }
+                );
+            }
+        );
+    };
+
+
     for (i = 0; i < versions.length; i += 1) {
         version = versions[i];
         if (TinCanTestCfg.recordStores[version]) {
             doSendStatementAsyncTest(version);
             doGetStatementAsyncTest(version);
-            if (version !== "0.9") {
-                doGetStatementsVerbIDAsyncTest(version);
-            }
             if (version !== "0.9" && version !== "0.95") {
+                doGetStatementsVerbIDAsyncTest(version);
                 doGetStatementsActivityIDAsyncTest(version);
+                doSendStatementWithAttachmentTest(version);
+                doGetStatementWithAttachmentTest(version);
+                doGetStatementsWithAttachmentTest(version);
             }
         }
     }

--- a/test/js/unit/TinCan-async.js
+++ b/test/js/unit/TinCan-async.js
@@ -242,7 +242,7 @@
                             id: "http://adlnet.gov/expapi/verbs/attempted"
                         },
                         target: {
-                            id: "http://tincanapi.com/TinCanJS/Test/TinCan_getStatements/async/" + v
+                            id: "http://tincanapi.com/TinCanJS/Test/TinCan_getStatement/async/" + v
                         }
                     },
                     function (results, sentStatement) {

--- a/test/js/unit/Utils.js
+++ b/test/js/unit/Utils.js
@@ -367,6 +367,22 @@
         }
     );
     test(
+        "getXAPIHashFromHeader",
+        function () {
+            var testHash = "testHashValue",
+                strings = {
+                    "X-Experience-API-Hash:testHashValue": testHash,
+                    "X-Experience-API-Hash:    testHashValue    ": testHash,
+                    "X-Experience-API-Hash:\r\n\ttestHashValue\r\n\t": testHash,
+                    "X-Experience-API-Hash: \ntestHashValue\n ": testHash
+                },
+                prop;
+            for (prop in strings) {
+                ok(TinCan.Utils.getXAPIHashFromHeader(prop) === strings[prop], "'" + prop + "' matches '" + strings[prop]);
+            }
+        }
+    );
+    test(
         "isApplicationJSON",
         function () {
             var okStrings = [

--- a/test/js/unit/Utils.js
+++ b/test/js/unit/Utils.js
@@ -77,6 +77,12 @@
         }
     );
     test(
+        "getSHA256String",
+        function () {
+            ok(TinCan.Utils.getSHA256String("test") === "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08", "return value");
+        }
+    );
+    test(
         "getBase64String",
         function () {
             ok(TinCan.Utils.getBase64String("a94a8fe5ccb19ba61c4c0873d391e987982fbbd3") === "YTk0YThmZTVjY2IxOWJhNjFjNGMwODczZDM5MWU5ODc5ODJmYmJkMw==", "return value");

--- a/test/js/unit/Utils.js
+++ b/test/js/unit/Utils.js
@@ -367,22 +367,6 @@
         }
     );
     test(
-        "getXAPIHashFromHeader",
-        function () {
-            var testHash = "testHashValue",
-                strings = {
-                    "X-Experience-API-Hash:testHashValue": testHash,
-                    "X-Experience-API-Hash:    testHashValue    ": testHash,
-                    "X-Experience-API-Hash:\r\n\ttestHashValue\r\n\t": testHash,
-                    "X-Experience-API-Hash: \ntestHashValue\n ": testHash
-                },
-                prop;
-            for (prop in strings) {
-                ok(TinCan.Utils.getXAPIHashFromHeader(prop) === strings[prop], "'" + prop + "' matches '" + strings[prop]);
-            }
-        }
-    );
-    test(
         "isApplicationJSON",
         function () {
             var okStrings = [

--- a/test/node-runner.js
+++ b/test/node-runner.js
@@ -30,7 +30,8 @@ else {
         "TinCan.js",
         "TinCan-async.js",
         "LRS.js",
-        "About.js"
+        "About.js",
+        "Attachment.js"
     ];
 }
 

--- a/test/single/Attachment.html
+++ b/test/single/Attachment.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <!--
-    Copyright 2014 Rustici Software
+    Copyright 2016 Rustici Software
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/test/single/Attachment.html
+++ b/test/single/Attachment.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<!--
+    Copyright 2014 Rustici Software
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<html>
+<head>
+    <title>TinCanJS Tests (Attachment)</title>
+    <link rel="stylesheet" href="../vendor/qunit-1.10.0pre.css" type="text/css" media="screen" />
+    <script src="../vendor/jquery-1.9.1.js"></script>
+    <script type="text/javascript" src="../vendor/qunit-1.10.0pre.js"></script>
+    <script type="text/javascript" src="../../build/tincan.js"></script>
+</head>
+<body>
+    <h1 id="qunit-header">TinCanJS Test Suite (Attachment)</h1>
+    <h2 id="qunit-banner"></h2>
+    <div id="qunit-testrunner-toolbar"></div>
+    <h2 id="qunit-userAgent"></h2>
+    <ol id="qunit-tests"></ol>
+
+    <script src="../js/BrowserPrep.js"></script>
+    <script src="../config.js"></script>
+    <script src="../js/unit/Attachment.js"></script>
+</body>
+</html>


### PR DESCRIPTION
Rebased with current master and fixed tests to support version 1.0.2

Addresses #70 

This PR includes the following:

- Attachments can now be added to statements and sent to the LRS

- The attachments' content is sent with the statement but not serialized with the rest of the statement's JSON

- The LRS sends the put request in the correct format if the statement has an attachment (and the correct `Content-Type`)

- If the attachment flag is set to `true` in `queryStatements()`, the response is formatted correctly (previously `queryStatements()` did not handle multipart requests, and would therefore not return the attachments' content)